### PR TITLE
Create GET request that pings server

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,6 +42,10 @@ app.get('/api/detailedPage/:id', function (req, res) {
     });
 })
 
+app.get('/', (req, res) => {
+  return res.send('Server pinged');
+});
+
 if (isDeveloping) {
   const compiler = webpack(config);
   const middleware = webpackMiddleware(compiler, {


### PR DESCRIPTION
I created a simple get request that pings the server. I have 2 options, I can automate the pinging by using a web service such as cron-job or I can call the get request on app load (not sure if that will be enough time because it takes 7-15 seconds to get a heroku server up and running from idle). What do you guys think is best?